### PR TITLE
Restore navigation bar visibility on exit

### DIFF
--- a/MediaBrowser/MediaBrowser.swift
+++ b/MediaBrowser/MediaBrowser.swift
@@ -1873,7 +1873,9 @@ public class MediaBrowser: UIViewController, UIScrollViewDelegate, UIActionSheet
         let animationDuration = CFTimeInterval(animated ? 0.35 : 0.0)
 
         // Navigation bar
-        self.navigationController?.setNavigationBarHidden(hidden, animated: true)
+        if viewIsActive {
+            self.navigationController?.setNavigationBarHidden(hidden, animated: true)
+        }
         
         // Status bar
         if !leaveStatusBarAlone {


### PR DESCRIPTION
Prior to this change, MediaBrowser would always set the navigation bar
to be visible when it was dismissed, even if the navigation bar had
been hidden previously.

This was happening becauese setControlsHidden is called from
viewWillDisappear _after_ restorePreviousNavBarAppearance.

This commit tries to fix that by not touching the navigation bar
visibility in setControlsHidden if the viewIsActive property is
false. The code in viewWillDisapper sets this to false when calling
restorePreviousNavBarAppearance.

I've tested this for my use case (where the previous bar was hidden),
but maybe this change might break other scenarios, so the maintainer
should see if there is perhaps a better way of fixing this bug.