### PR TITLE
Provide an option to disable grid animations

### DIFF
--- a/MediaBrowser/MediaBrowser.swift
+++ b/MediaBrowser/MediaBrowser.swift
@@ -150,6 +150,10 @@ public class MediaBrowser: UIViewController, UIScrollViewDelegate, UIActionSheet
     
     /// Start on Grid
     public var startOnGrid = false
+
+    /// If you observe flashes to the screen when you move between the grid
+    /// and the photos, set this to true to disable the transition animations.
+    public var disableGridAnimations = false
     
     /// Auto play video on appear
     public var autoPlayOnAppear = false
@@ -1799,15 +1803,25 @@ public class MediaBrowser: UIViewController, UIScrollViewDelegate, UIActionSheet
             
             // Animate grid in and photo scroller out
             gc.willMove(toParentViewController: self)
-            UIView.animate(
-                withDuration: animated ? 0.3 : 0,
-                animations: {
-                    gc.view.alpha = 1.0
-                    self.pagingScrollView.alpha = 0.0
-                },
-                completion: { finished in
-                    gc.didMove(toParentViewController: self)
-                })
+
+            let changes: () -> Void = {
+                gc.view.alpha = 1.0
+                self.pagingScrollView.alpha = 0.0
+            }
+
+            let completion: (Bool) -> Void = { _ in
+                gc.didMove(toParentViewController: self)
+            }
+
+            if disableGridAnimations {
+                changes()
+                completion(true)
+            } else {
+                UIView.animate(
+                    withDuration: animated ? 0.3 : 0,
+                    animations: changes,
+                    completion: completion)
+            }
         }
     }
 
@@ -1837,21 +1851,30 @@ public class MediaBrowser: UIViewController, UIScrollViewDelegate, UIActionSheet
             view.layoutSubviews()
             
             self.pagingScrollView.frame = self.frameForPagingScrollView
-            
-            // Animate, hide grid and show paging scroll view
-            UIView.animate(
-                withDuration: 0.3,
-                animations: {
-                    gc.view.alpha = 0.0
-                    self.pagingScrollView.alpha = 1.0
-                },
-                completion: { finished in
-                    gc.willMove(toParentViewController: nil)
-                    gc.view.removeFromSuperview()
-                    gc.removeFromParentViewController()
-            
-                    self.setControlsHidden(hidden: false, animated: true, permanent: false) // retrigger timer
-                })
+
+            let changes: () -> Void = {
+                gc.view.alpha = 0.0
+                self.pagingScrollView.alpha = 1.0
+            }
+
+            let completion: (Bool) -> Void = { _ in
+                gc.willMove(toParentViewController: nil)
+                gc.view.removeFromSuperview()
+                gc.removeFromParentViewController()
+
+                self.setControlsHidden(hidden: false, animated: true, permanent: false) // retrigger timer
+            }
+
+            if disableGridAnimations {
+                changes()
+                completion(true)
+            } else {
+                // Animate, hide grid and show paging scroll view
+                UIView.animate(
+                    withDuration: 0.3,
+                    animations: changes,
+                    completion: completion)
+            }
         }
     }
 


### PR DESCRIPTION
I was consistenly seeing flashes of white (iPhone X, iOS 11) when
transitioning between the grid and the photos view.

This commit provides a switch to turn off the transitions
animations. With this set to true, I no longer observe these flashes
in my project. However, this switch is by default set to false, so no
existing code will be impacted by this change.

If you do not observe this problem, feel free to close this pull request without
merging 👍🏼