### PR TITLE
Tweaks to support Objective C

### DIFF
--- a/MediaBrowser/MediaBrowser.swift
+++ b/MediaBrowser/MediaBrowser.swift
@@ -16,7 +16,7 @@ func floorcgf(x: CGFloat) -> CGFloat {
 }
 
 /// MediaBrwoser is based in UIViewController, UIScrollViewDelegate and UIActionSheetDelegate. So you can push, or make modal.
-open class MediaBrowser: UIViewController, UIScrollViewDelegate, UIActionSheetDelegate, AVPlayerViewControllerDelegate {
+@objcMembers public class MediaBrowser: UIViewController, UIScrollViewDelegate, UIActionSheetDelegate, AVPlayerViewControllerDelegate {
     private let padding = CGFloat(0.0)
 
     // Data

--- a/MediaBrowser/MediaBrowserDelegate.swift
+++ b/MediaBrowser/MediaBrowserDelegate.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// Required delegate to use MediaBrowser
-public protocol MediaBrowserDelegate: class {
+@objc public protocol MediaBrowserDelegate: class {
     //MARK: Required methods
     
     /**
@@ -100,7 +100,7 @@ public protocol MediaBrowserDelegate: class {
      Optional protocol for grid cells resizing
      - Returns: Optional CGSize
      */
-    func gridCellSize() -> CGSize?
+    func gridCellSize() -> CGSize
 
     /**
      Optional protocol for access token
@@ -127,7 +127,7 @@ public extension MediaBrowserDelegate {
     
     func title(for mediaBrowser: MediaBrowser, at index: Int) -> String? { return nil }
     
-    func gridCellSize() -> CGSize? { return nil }
+    func gridCellSize() -> CGSize { return CGSize(width: 128, height: 128) }
 
     func accessToken(for url: URL?) -> String? { return nil }
 }


### PR DESCRIPTION
These are the changes I had to make so far to get my (admittedly, quite old) Objective C app to use Media Browser. Everything seems to be working well, except for two issues, one of which I'll cover in a separate ticket #67.

1. All Delegate methods must be implemented (I can't figure out how to get the defaults to work)
2. I'm having minor issues with the grid and video icon, as described in #67