### PR TITLE
Add `@objc optional` to MediaBrowserDelegate functions

### DIFF
--- a/MediaBrowser/MediaBrowserDelegate.swift
+++ b/MediaBrowser/MediaBrowserDelegate.swift
@@ -34,7 +34,7 @@ import UIKit
      
      - Parameter mediaBrowser: MediaBrowser
      */
-    func mediaBrowserDidFinishModalPresentation(mediaBrowser: MediaBrowser)
+    @objc optional func mediaBrowserDidFinishModalPresentation(mediaBrowser: MediaBrowser)
 
     /**
      Optional protocol to show thumbnail. return media.
@@ -43,7 +43,7 @@ import UIKit
      - Parameter mediaBrowser: MediaBrowser
      - Parameter index: Int
      */
-    func thumbnail(for mediaBrowser: MediaBrowser, at index: Int) -> Media
+    @objc optional func thumbnail(for mediaBrowser: MediaBrowser, at index: Int) -> Media
 
     /**
      Optional protocol to show captionView. return MediaCaptionView.
@@ -51,7 +51,7 @@ import UIKit
      - Parameter mediaBrowser: MediaBrowser
      - Parameter index: Int
      */
-    func captionView(for mediaBrowser: MediaBrowser, at index: Int) -> MediaCaptionView?
+    @objc optional func captionView(for mediaBrowser: MediaBrowser, at index: Int) -> MediaCaptionView?
     
     /**
      Optional protocol when need callback
@@ -59,7 +59,7 @@ import UIKit
      - Parameter index: Int
      - Parameter mediaBrowser: MediaBrowser
      */
-    func didDisplayMedia(at index: Int, in mediaBrowser: MediaBrowser)
+    @objc optional func didDisplayMedia(at index: Int, in mediaBrowser: MediaBrowser)
     
     /**
      Optional protocol when need callback about action button
@@ -67,7 +67,7 @@ import UIKit
      - Parameter photoIndex: Int
      - Parameter mediaBrowser: MediaBrowser
      */
-    func actionButtonPressed(at photoIndex: Int, in mediaBrowser: MediaBrowser, sender: Any?)
+    @objc optional func actionButtonPressed(at photoIndex: Int, in mediaBrowser: MediaBrowser, sender: Any?)
     
     
     /**
@@ -76,7 +76,7 @@ import UIKit
      - Parameter index: Int
      - Parameter mediaBrowser: MediaBrowser
      */
-    func isMediaSelected(at index: Int, in mediaBrowser: MediaBrowser) -> Bool
+    @objc optional func isMediaSelected(at index: Int, in mediaBrowser: MediaBrowser) -> Bool
     
     /**
      Optional protocol when need callback about media selection
@@ -85,7 +85,7 @@ import UIKit
      - Parameter index: Int
      - Parameter mediaBrowser: MediaBrowser
      */
-    func mediaDid(selected: Bool, at index: Int, in mediaBrowser: MediaBrowser)
+    @objc optional func mediaDid(selected: Bool, at index: Int, in mediaBrowser: MediaBrowser)
     
     
     /**
@@ -94,18 +94,18 @@ import UIKit
      - Parameter mediaBrowser: MediaBrowser
      - Parameter index: Int
      */
-    func title(for mediaBrowser: MediaBrowser, at index: Int) -> String?
+    @objc optional func title(for mediaBrowser: MediaBrowser, at index: Int) -> String?
     
     /**
      Optional protocol for grid cells resizing
      - Returns: Optional CGSize
      */
-    func gridCellSize() -> CGSize
+    @objc optional func gridCellSize() -> CGSize
 
     /**
      Optional protocol for access token
      */
-    func accessToken(for url: URL?) -> String?
+    @objc optional func accessToken(for url: URL?) -> String?
 }
 
 public extension MediaBrowserDelegate {


### PR DESCRIPTION
Hi 
Since #68 has changed the protocol `MediaBrowserDelegate` with `@objc`, and all optional methods became required.
I suggest these optionals need a decoration `@objc optional` to apply default behavior from extensions.
